### PR TITLE
Add back a VBlank wait loop to the reset vector

### DIFF
--- a/asm/vector/rst.asm
+++ b/asm/vector/rst.asm
@@ -19,6 +19,12 @@ RST:
     STX PPU_MASK     ; Disable Rendering
     STX APU_DMC_FREQ ; Disable DMC IRQ
 
+    ; Wait 1 frame (for the PPU to be initialized)
+    BIT PPU_STATUS ; Clear the VBlank flag if it was set at reset time
+    @wait_vblank:
+        BIT PPU_STATUS
+        BPL @wait_vblank ; At this point, about 27384 cycles have passed
+
     ; Clear NES RAM
     @clrmem:
         LDA #$00


### PR DESCRIPTION
Hello. I tried booting up the game in Mesen like the instructions said, then ran into a problem where the game was hanging on an all-green screen. So I tried figuring out what caused the problem.

At some point (maybe after PRG-RAM was removed?), the initialization code in `RST` became too fast, only about 19'000 cycles, which isn't long enough for the NES PPU to be fully initialized. It needs about 30'000 cycles. This caused writes to `PPU_CTRL` and other registers to not work, which made NMI never happen. It seems Mesen doesn't try to emulate this by default; it's hidden away in the NES Emulation settings with a red "Not recommended" warning to discourage casual users from enabling it, and I had that setting enabled for some reason.

This PR adds one of the loops back, which effectively adds 27K cycles back into the initialization code, which should be more than enough for the code to start working again on an NTSC NES.